### PR TITLE
Strip debug symbol to reduce binary size

### DIFF
--- a/crosscompile.sh
+++ b/crosscompile.sh
@@ -7,5 +7,5 @@ for target in darwin:amd64 linux:amd64 linux:386 linux:arm windows:amd64; do
   if [ "$GOOS" = "windows" ]; then
     EXT=".exe"
   fi
-  bash -c "go build -o $(basename $(echo $PWD))_${GOOS}_${GOARCH}${EXT} ."
+  bash -c "go build -ldflags "-s -w" -o $(basename $(echo $PWD))_${GOOS}_${GOARCH}${EXT} ."
 done


### PR DESCRIPTION
Debug symbol is only useful if you ever need to use gdb to final executable.

This is especially useful for Windows (currently the largest binary), saves about 32% in binary size.

Original: 6648KB
Stripped: 4509KB