### PR TITLE
call gzip for all text-based formats

### DIFF
--- a/simplehttp2server.go
+++ b/simplehttp2server.go
@@ -69,7 +69,9 @@ func main() {
 		typ := mime.TypeByExtension(r.URL.Path)
 		switch {
 		case strings.HasPrefix(typ, "text/"):
+			fallthrough
 		case typ == "application/xml":
+			fallthrough
 		case typ == "":
 			fs = gziphandler.GzipHandler(fs)
 		}


### PR DESCRIPTION
This fixes a subtle bug that prevented some text-based formats from being gzipped.

Contrary to other languages (where the fall through is implicit and you need to call break explicitly) in Go the break is implicit and you need to explicitly fall through to other cases in a switch.

From the [Go tour](https://tour.golang.org/flowcontrol/9):
> Go's switch is like the one in C, C++, Java, JavaScript, and PHP, except that Go only runs the selected case, not all the cases that follow. In effect, the break statement that is needed at the end of each case in those languages is provided automatically in Go.

Demonstration on the Go playground: [https://play.golang.org/p/7g39bJz_4CH](https://play.golang.org/p/7g39bJz_4CH)